### PR TITLE
Feature/cars

### DIFF
--- a/src/routes/cars/CarRouter.test.ts
+++ b/src/routes/cars/CarRouter.test.ts
@@ -1,0 +1,391 @@
+import chai, { expect } from "chai";
+import cookieParser from "cookie-parser";
+import express, { NextFunction, Response } from "express";
+import createHttpError from "http-errors";
+import { StatusCodes } from "http-status-codes";
+import Sinon from "sinon";
+import sinonChai from "sinon-chai";
+import supertest from "supertest";
+import { Request } from "../../commons/interfaces";
+import { RouteUtilities } from "../../commons/RouteUtilities";
+import { CarRouter } from "./CarRouter";
+import { CarServices } from "./CarServices";
+import { CarStatus } from "./enums";
+import { SearchCarsCriteria } from "./interfaces";
+
+chai.use(sinonChai);
+
+describe("CarRouter", function () {
+  const sandbox = Sinon.createSandbox();
+
+  const carServices = sandbox.createStubInstance(CarServices);
+
+  const authenticateJWTMiddleware = sandbox.fake(
+    (req: Request, res: Response, next: NextFunction) => {
+      next();
+    }
+  );
+  const validateSchemaMiddleware = sandbox.fake(
+    async (req: Request, res: Response, next: NextFunction) => {
+      next();
+    }
+  );
+  const errorHandlingMiddleware = sandbox.fake(
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).send(err.message);
+    }
+  );
+
+  const routeUtilities = sandbox.createStubInstance(RouteUtilities, {
+    authenticateJWT: sandbox.stub().callsFake(() => authenticateJWTMiddleware),
+    validateSchema: sandbox.stub().callsFake(() => validateSchemaMiddleware),
+    errorHandling: sandbox.stub().callsFake(() => errorHandlingMiddleware),
+  });
+
+  const carRouter = new CarRouter({ routeUtilities, carServices });
+
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use("/cars", carRouter.getRouterInstance());
+  app.use(routeUtilities.errorHandling());
+
+  const request = supertest(app);
+
+  describe("GET /cars", function () {
+    beforeEach(function () {
+      carServices.getCars.callsFake((payload: SearchCarsCriteria) =>
+        Promise.resolve({
+          cars: [],
+          count: 0,
+        })
+      );
+    });
+
+    afterEach(function () {
+      carServices.getCars.reset();
+    });
+
+    it("should call middleware authencticateJWT", async function () {
+      await request.get("/cars");
+      expect(authenticateJWTMiddleware).to.be.calledOnce;
+    });
+
+    it("should return 200 with result from carServices.getCars", async function () {
+      const response = await request.get("/cars");
+      expect(response.status).to.equal(200);
+      expect(response.body).to.deep.equal({
+        cars: [],
+        count: 0,
+      });
+    });
+
+    it("should call middleware errorHandling if there is an error", async function () {
+      carServices.getCars.rejects(
+        new createHttpError.InternalServerError("Some error.")
+      );
+      const response = await request.get("/cars");
+      expect(errorHandlingMiddleware).to.be.calledOnce;
+    });
+
+    describe("licensePlate", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with licensePlate = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].licensePlate).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with licensePlate = undefined", async function () {
+          await request.get("/cars?licensePlate=");
+          expect(carServices.getCars.getCalls()[0].args[0].licensePlate).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty string", function () {
+        it("should call carServices.getCars with that licensePlate", async function () {
+          await request.get("/cars?licensePlate=AA-0000");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].licensePlate
+          ).to.be.equal("AA-0000");
+        });
+      });
+    });
+
+    describe("model", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with model = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].model).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with model = undefined", async function () {
+          await request.get("/cars?model=");
+          expect(carServices.getCars.getCalls()[0].args[0].model).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty string", function () {
+        it("should call carServices.getCars with that model", async function () {
+          await request.get("/cars?model=T1");
+          expect(carServices.getCars.getCalls()[0].args[0].model).to.be.equal(
+            "T1"
+          );
+        });
+      });
+    });
+
+    describe("imageFilename", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with imageFilename = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].imageFilename).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with imageFilename = undefined", async function () {
+          await request.get("/cars?imageFilename=");
+          expect(carServices.getCars.getCalls()[0].args[0].imageFilename).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty string", function () {
+        it("should call carServices.getCars with that imageFilename", async function () {
+          await request.get("/cars?imageFilename=T1");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].imageFilename
+          ).to.be.equal("T1");
+        });
+      });
+    });
+
+    describe("status", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with status = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].status).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with status = undefined", async function () {
+          await request.get("/cars?status=");
+          expect(carServices.getCars.getCalls()[0].args[0].status).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty string that is not 'INACTIVE'", function () {
+        it("should call carServices.getCars with status = CarStatus.Active", async function () {
+          await request.get("/cars?status=pending");
+          expect(carServices.getCars.getCalls()[0].args[0].status).to.be.equal(
+            CarStatus.Active
+          );
+        });
+      });
+      describe("is 'INACTIVE'", function () {
+        it("should call carServices.getCars with status = CarStatus.Inactive", async function () {
+          await request.get("/cars?status=INACTIVE");
+          expect(carServices.getCars.getCalls()[0].args[0].status).to.be.equal(
+            CarStatus.Inactive
+          );
+        });
+      });
+    });
+
+    describe("minPassengers", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with minPassengers = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].minPassengers).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with minPassengers = undefined", async function () {
+          await request.get("/cars?minPassengers=");
+          expect(carServices.getCars.getCalls()[0].args[0].minPassengers).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty numeric string", function () {
+        it("should call carServices.getCars with that integer parsed minPassengers", async function () {
+          await request.get("/cars?minPassengers=5");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].minPassengers
+          ).to.be.equal(5);
+        });
+      });
+      describe("is a non-empty non-numeric string", function () {
+        it("should call carServices.getCars with minPassengers = NaN", async function () {
+          await request.get("/cars?minPassengers=five");
+          expect(carServices.getCars.getCalls()[0].args[0].minPassengers).to.be
+            .NaN;
+        });
+      });
+    });
+
+    describe("maxPassengers", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with maxPassengers = undefined", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].maxPassengers).to.be
+            .undefined;
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with maxPassengers = undefined", async function () {
+          await request.get("/cars?maxPassengers=");
+          expect(carServices.getCars.getCalls()[0].args[0].maxPassengers).to.be
+            .undefined;
+        });
+      });
+      describe("is a non-empty numeric string", function () {
+        it("should call carServices.getCars with that integer parsed maxPassengers", async function () {
+          await request.get("/cars?maxPassengers=5");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].maxPassengers
+          ).to.be.equal(5);
+        });
+      });
+      describe("is a non-empty non-numeric string", function () {
+        it("should call carServices.getCars with maxPassengers = NaN", async function () {
+          await request.get("/cars?maxPassengers=five");
+          expect(carServices.getCars.getCalls()[0].args[0].maxPassengers).to.be
+            .NaN;
+        });
+      });
+    });
+
+    describe("limit", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with limit = 0", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].limit).to.be.equal(
+            0
+          );
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with limit = 0", async function () {
+          await request.get("/cars?limit=");
+          expect(carServices.getCars.getCalls()[0].args[0].limit).to.be.equal(
+            0
+          );
+        });
+      });
+      describe("is a non-empty numeric string", function () {
+        it("should call carServices.getCars with that integer parsed limit", async function () {
+          await request.get("/cars?limit=5");
+          expect(carServices.getCars.getCalls()[0].args[0].limit).to.be.equal(
+            5
+          );
+        });
+      });
+      describe("is a non-empty non-numeric string", function () {
+        it("should call carServices.getCars with limit = NaN", async function () {
+          await request.get("/cars?limit=five");
+          expect(carServices.getCars.getCalls()[0].args[0].limit).to.be.NaN;
+        });
+      });
+    });
+
+    describe("offset", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with offset = 0", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].offset).to.be.equal(
+            0
+          );
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with offset = 0", async function () {
+          await request.get("/cars?offset=");
+          expect(carServices.getCars.getCalls()[0].args[0].offset).to.be.equal(
+            0
+          );
+        });
+      });
+      describe("is a non-empty numeric string", function () {
+        it("should call carServices.getCars with that integer parsed offset", async function () {
+          await request.get("/cars?offset=5");
+          expect(carServices.getCars.getCalls()[0].args[0].offset).to.be.equal(
+            5
+          );
+        });
+      });
+      describe("is a non-empty non-numeric string", function () {
+        it("should call carServices.getCars with offset = NaN", async function () {
+          await request.get("/cars?offset=five");
+          expect(carServices.getCars.getCalls()[0].args[0].offset).to.be.NaN;
+        });
+      });
+    });
+
+    describe("orderBy", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with orderBy = 'id'", async function () {
+          await request.get("/cars");
+          expect(carServices.getCars.getCalls()[0].args[0].orderBy).to.be.equal(
+            "id"
+          );
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with orderBy = 'id'", async function () {
+          await request.get("/cars?orderBy=");
+          expect(carServices.getCars.getCalls()[0].args[0].orderBy).to.be.equal(
+            "id"
+          );
+        });
+      });
+      describe("is a non-empty string", function () {
+        it("should call carServices.getCars with that orderBy", async function () {
+          await request.get("/cars?orderBy=licensePlate");
+          expect(carServices.getCars.getCalls()[0].args[0].orderBy).to.be.equal(
+            "licensePlate"
+          );
+        });
+      });
+    });
+
+    describe("orderDir", function () {
+      describe("is not provided", function () {
+        it("should call carServices.getCars with orderDir = 'asc'", async function () {
+          await request.get("/cars");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].orderDir
+          ).to.be.equal("asc");
+        });
+      });
+      describe("is an empty string", function () {
+        it("should call carServices.getCars with orderDir = 'asc'", async function () {
+          await request.get("/cars?orderDir=");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].orderDir
+          ).to.be.equal("asc");
+        });
+      });
+      describe("is a non-empty string other than 'desc'", function () {
+        it("should call carServices.getCars with orderDir = 'asc'", async function () {
+          await request.get("/cars?orderDir=zigzag");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].orderDir
+          ).to.be.equal("asc");
+        });
+      });
+      describe("is 'desc'", function () {
+        it("should call carServices.getCars with orderDir = 'desc'", async function () {
+          await request.get("/cars?orderDir=desc");
+          expect(
+            carServices.getCars.getCalls()[0].args[0].orderDir
+          ).to.be.equal("desc");
+        });
+      });
+    });
+  });
+});

--- a/src/routes/cars/CarRouter.ts
+++ b/src/routes/cars/CarRouter.ts
@@ -148,9 +148,28 @@ export class CarRouter {
         next: NextFunction
       ) => {
         try {
+          let licensePlate = undefined;
+          if (!isEmpty(req.query.licensePlate)) {
+            licensePlate = req.query.licensePlate;
+          }
+
+          let model = undefined;
+          if (!isEmpty(req.query.model)) {
+            model = req.query.model;
+          }
+
+          let imageFilename = undefined;
+          if (!isEmpty(req.query.imageFilename)) {
+            imageFilename = req.query.imageFilename;
+          }
+
           let status = undefined;
           if (!isEmpty(req.query.status)) {
-            status = req.query.status as CarStatus;
+            if (req.query.status === CarStatus.Inactive) {
+              status = CarStatus.Inactive;
+            } else {
+              status = CarStatus.Active;
+            }
           }
 
           let minPassengers = undefined;
@@ -179,12 +198,14 @@ export class CarRouter {
           }
 
           let orderDir = "asc" as "asc" | "desc";
-          if (req.body.orderDir === "desc") {
+          if (req.query.orderDir === "desc") {
             orderDir = "desc";
           }
 
           const payload = {
-            ...req.query,
+            licensePlate,
+            model,
+            imageFilename,
             status,
             minPassengers,
             maxPassengers,

--- a/src/routes/cars/interfaces.ts
+++ b/src/routes/cars/interfaces.ts
@@ -26,12 +26,12 @@ export interface SearchCarsCriteriaQuery extends core.Query {
 }
 
 export interface SearchCarsCriteria {
-  licensePlate?: string;
-  model?: string;
-  imageFilename?: string;
-  status?: CarStatus;
-  minPassengers?: number;
-  maxPassengers?: number;
+  licensePlate: string | undefined;
+  model: string | undefined;
+  imageFilename: string | undefined;
+  status: CarStatus | undefined;
+  minPassengers: number | undefined;
+  maxPassengers: number | undefined;
   limit: number;
   offset: number;
   orderBy: string;


### PR DESCRIPTION
### Description
Added test for CarRouter GET /cars.

### Changes
- Added CarRouter.test.ts.
- Fixed code in CarRouter to satisfy the test.

### Test Result
```
  CarRouter
    GET /cars
      ✔ should call middleware authencticateJWT
      ✔ should return 200 with result from carServices.getCars
      ✔ should call middleware errorHandling if there is an error
      licensePlate
        is not provided
          ✔ should call carServices.getCars with licensePlate = undefined
        is an empty string
          ✔ should call carServices.getCars with licensePlate = undefined
        is a non-empty string
          ✔ should call carServices.getCars with that licensePlate
      model
        is not provided
          ✔ should call carServices.getCars with model = undefined
        is an empty string
          ✔ should call carServices.getCars with model = undefined
        is a non-empty string
          ✔ should call carServices.getCars with that model
      imageFilename
        is not provided
          ✔ should call carServices.getCars with imageFilename = undefined
        is an empty string
          ✔ should call carServices.getCars with imageFilename = undefined
        is a non-empty string
          ✔ should call carServices.getCars with that imageFilename
      status
        is not provided
          ✔ should call carServices.getCars with status = undefined
        is an empty string
          ✔ should call carServices.getCars with status = undefined
        is a non-empty string that is not 'INACTIVE'
          ✔ should call carServices.getCars with status = CarStatus.Active
        is 'INACTIVE'
          ✔ should call carServices.getCars with status = CarStatus.Inactive
      minPassengers
        is not provided
          ✔ should call carServices.getCars with minPassengers = undefined
        is an empty string
          ✔ should call carServices.getCars with minPassengers = undefined
        is a non-empty numeric string
          ✔ should call carServices.getCars with that integer parsed minPassengers
        is a non-empty non-numeric string
          ✔ should call carServices.getCars with minPassengers = NaN
      maxPassengers
        is not provided
          ✔ should call carServices.getCars with maxPassengers = undefined
        is an empty string
          ✔ should call carServices.getCars with maxPassengers = undefined
        is a non-empty numeric string
          ✔ should call carServices.getCars with that integer parsed maxPassengers
        is a non-empty non-numeric string
          ✔ should call carServices.getCars with maxPassengers = NaN
      limit
        is not provided
          ✔ should call carServices.getCars with limit = 0
        is an empty string
          ✔ should call carServices.getCars with limit = 0
        is a non-empty numeric string
          ✔ should call carServices.getCars with that integer parsed limit
        is a non-empty non-numeric string
          ✔ should call carServices.getCars with limit = NaN
      offset
        is not provided
          ✔ should call carServices.getCars with offset = 0
        is an empty string
          ✔ should call carServices.getCars with offset = 0
        is a non-empty numeric string
          ✔ should call carServices.getCars with that integer parsed offset
        is a non-empty non-numeric string
          ✔ should call carServices.getCars with offset = NaN
      orderBy
        is not provided
          ✔ should call carServices.getCars with orderBy = 'id'
        is an empty string
          ✔ should call carServices.getCars with orderBy = 'id'
        is a non-empty string
          ✔ should call carServices.getCars with that orderBy
      orderDir
        is not provided
          ✔ should call carServices.getCars with orderDir = 'asc'
        is an empty string
          ✔ should call carServices.getCars with orderDir = 'asc'
        is a non-empty string other than 'desc'
          ✔ should call carServices.getCars with orderDir = 'asc'
        is 'desc'
          ✔ should call carServices.getCars with orderDir = 'desc'


  39 passing (161ms)
```